### PR TITLE
fix: remove maxHeight of buttons in button group

### DIFF
--- a/src/components/TicketsButtons.tsx
+++ b/src/components/TicketsButtons.tsx
@@ -30,14 +30,13 @@ export default function BasicButtonGroup({id, barcode, setTickets, tickets}: Bas
     const linkUrl = `${import.meta.env.VITE_PO_URL}/cgi/product.pl?type=edit&code=${barcode}`;
 
     return (
-        <ButtonGroup variant="contained" aria-label="ticket_actions">
+        <ButtonGroup variant="contained" aria-label="ticket_actions" >
             <Button 
                 component={Link} 
                 to={linkUrl} 
                 variant='contained'
                 color="inherit"
                 endIcon={<EditIcon />}
-                sx={{ maxHeight: '40px' }}
                 target="_blank" >
                 Edit
             </Button>
@@ -45,7 +44,6 @@ export default function BasicButtonGroup({id, barcode, setTickets, tickets}: Bas
                 variant="contained"
                 color="error"
                 endIcon={<NotInterestedIcon />}
-                sx={{ maxHeight: '40px' }}
                 onClick={() => handleStatus(id, 'closed')}
             >
                 No problem
@@ -54,7 +52,6 @@ export default function BasicButtonGroup({id, barcode, setTickets, tickets}: Bas
                 variant="contained"
                 color="success"
                 endIcon={<CheckIcon />}
-                sx={{ maxHeight: '40px' }}
                 onClick={() => handleStatus(id, 'closed')}
             >
                 I fixed it!


### PR DESCRIPTION
### What
Fix padding issue on small screens

### Screensh

Before : 
<img width="178" height="71" alt="Capture d’écran 2025-07-23 à 10 02 51" src="https://github.com/user-attachments/assets/c9b613de-b337-4382-ae5f-d01822185f47" />
ot

After : 
<img width="179" height="59" alt="Capture d’écran 2025-07-23 à 10 03 15" src="https://github.com/user-attachments/assets/d93300d9-4633-4e86-b78a-cbbd9b3d2594" />


### Fixes bug(s)
