### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -1,3 +1,4 @@
+permissions: {}
 name: Ventilate issues to the right GitHub projects
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/2](https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key at the workflow or job level to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow uses a custom token for all project board operations and does not appear to require any write access via `GITHUB_TOKEN`, the safest minimal setting is `permissions: {}` (no permissions). If future steps require read access to repository contents, you can use `contents: read`. The best place to add this is at the top level of the workflow (just after the `name:`), so it applies to all jobs. No other code changes are needed.

**Steps:**
- Insert a `permissions: {}` block after the `name:` line (line 1).
- No imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
