### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -1,3 +1,7 @@
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 name: Top issues action.
 #on:
 #  schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/7](https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the action is labeling issues and possibly updating dashboards (which may involve writing to issues and pull requests), the minimal permissions should be `contents: read`, `issues: write`, and `pull-requests: write`. This block can be added at the workflow level (top-level, after `name:` and before `on:`) or at the job level (under `ShowAndLabelTopIssues:`). The best practice is to add it at the workflow level so all jobs inherit these permissions unless overridden.

**What to change:**  
- In `.github/workflows/top-issues.yml`, add the following block after the `name:` line and before the `on:` block:
  ```yaml
  permissions:
    contents: read
    issues: write
    pull-requests: write
  ```
- No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
