### PR TITLE
fix: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: '💥 Auto-Label Merge Conflicts on PRs'
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/4](https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to only the permissions required for the job. In this case, the workflow uses the token to label pull requests, so it needs `pull-requests: write` and possibly `contents: read` (if the action reads repository contents, which is common). The `permissions` block should be added at the workflow root (before `jobs:`) to apply to all jobs, unless more granular control is needed. Edit `.github/workflows/merge-conflict-autolabel.yml` to insert the following block after the `name:` and before `on:`:

```yaml
permissions:
  contents: read
  pull-requests: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
