### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/pages/FlagFormPage.tsx
+++ b/src/pages/FlagFormPage.tsx
@@ -64,6 +64,12 @@ export default function FlagForm({ type_ }: FlagFormProps) {
     });
     const [image, setImage] = useState<string | null>(null);
 
+    // Helper function to validate imageId and barcode
+    const isValidId = (value: string | undefined) => {
+        // Only allow alphanumeric, underscore, hyphen
+        return typeof value === 'string' && /^[a-zA-Z0-9_-]+$/.test(value);
+    };
+
     useEffect(() => {
         const buildUrl = (barcode: string, imageId: string, def: string, rev?: string) => {
             // split the barcode into 4 parts
@@ -79,13 +85,18 @@ export default function FlagForm({ type_ }: FlagFormProps) {
             return `${import.meta.env.VITE_PO_IMAGE_URL}/images/products/${part1}/${part2}/${part3}/${part4}/${imageId}.${def}.jpg`;
         }
         if (type_ === 'image') {
-            const url = buildUrl(formData.barcode, formData.image_id as string, '400');
-            axios.get(url).then(() => {
-                setImage(url);
+            // Validate barcode and image_id before using them
+            if (isValidId(formData.barcode) && isValidId(formData.image_id as string)) {
+                const url = buildUrl(formData.barcode, formData.image_id as string, '400');
+                axios.get(url).then(() => {
+                    setImage(url);
+                }
+                ).catch((err) => {
+                    console.error(err);
+                })
+            } else {
+                setImage(null);
             }
-            ).catch((err) => {
-                console.error(err);
-            })
         }
     }, [formData.type]);
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/1](https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/1)

To fix this issue, we should ensure that the `image_id` (and potentially `barcode`) used to construct the image URL are validated to contain only safe characters (e.g., alphanumeric, possibly underscores or hyphens). This prevents an attacker from injecting malicious content into the URL. The best way is to sanitize or validate these values before using them in the URL construction. We can add a helper function to validate that `image_id` and `barcode` match a safe pattern (e.g., `/^[a-zA-Z0-9_-]+$/`). If the values do not match, we should not attempt to load the image, and optionally display an error.

The changes should be made in `src/pages/FlagFormPage.tsx`:
- Add a validation function for `image_id` and `barcode`.
- Use this function in the `useEffect` that sets the image URL.
- If validation fails, do not set the image (or set an error state).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
