### PR TITLE
fix: Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: "Semantic PRs"
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/6](https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the job. Since the workflow is triggered on `pull_request_target` and uses the `amannn/action-semantic-pull-request` action, the minimal permissions required are typically `contents: read` (to read the PR) and `pull-requests: write` (to update PR status checks). The `permissions` block can be added at the workflow root (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add it at the workflow root unless different jobs require different permissions. In this case, adding it at the root is sufficient and clear.

**What to change:**  
- In `.github/workflows/semantic-pr.yml`, add the following block after the `name` field and before the `on` field:
  ```yaml
  permissions:
    contents: read
    pull-requests: write
  ```
- No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
