### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,7 @@
 name: Run release-please
+permissions:
+  contents: write
+  pull-requests: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/21](https://github.com/openfoodfacts/nutripatrol-frontend/security/code-scanning/21)

To fix the problem, explicitly declare the GitHub Actions `permissions` at either the workflow root or per job. This restricts the default permissions of GITHUB_TOKEN used by actions in the workflow and enforces the principle of least privilege. For release-please, the minimal permissions required are typically:  
- `contents: write` (to create/update release tags and files)
- `pull-requests: write` (to open/close/update PRs)  

You should add a block like:
```yaml
permissions:
  contents: write
  pull-requests: write
```
immediately after the workflow `name:` and before the `on:` block, or within the specific job under `jobs.release-please`. The root-level position ensures all jobs in the workflow use it unless overridden locally. The change only modifies workflow configuration, not the actual logic of release-please.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
