### PR TITLE
feat: add infrastructure for JS SDK integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^5.15.0",
     "@mui/material": "^5.15.0",
+    "@openfoodfacts/openfoodfacts-nodejs": "2.0.0-alpha.29",
     "axios": "^1.13.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -32,5 +33,6 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import {
 } from "react-router-dom";
 import { useState, useCallback, useRef, useEffect } from "react";
 import off from "./off.ts";
+// @ts-ignore
+import { offClient } from "./api.ts";
 import axios from "axios";
 
 import HomePage from './pages/HomePage.tsx'
@@ -79,6 +81,11 @@ export default function App() {
       // If the request is successful, set the user state to logged in
       .then(response => {
         const cookieUserName = off.getUsername();
+        
+        // TODO(sdk-bump): Switch to SDK's offClient.getLoginStatus() once SDK version is bumped
+        // const { data, error } = await offClient.getLoginStatus();
+        // const userData = data?.user;
+        
         const userData = response.data.user;
         setUserState(prevState => ({
           ...prevState,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,23 @@
+import { OpenFoodFacts, NutriPatrol } from "@openfoodfacts/openfoodfacts-nodejs";
+
+/**
+ * Custom fetch wrapper to ensure cookies are sent with cross-origin requests.
+ * Nutri-Patrol frontend relies on the 'session' cookie from OpenFoodFacts.
+ */
+const customFetch: typeof fetch = (url, init) => {
+    return fetch(url, { ...init, credentials: "include" });
+};
+
+// Initialize the main Open Food Facts client
+export const offClient = new OpenFoodFacts(customFetch, { 
+    host: import.meta.env.VITE_PO_URL || "https://world.openfoodfacts.org" 
+});
+
+// Initialize the Nutri-Patrol specific client
+// TODO(sdk-bump): Use offClient.nutriPatrol directly once SDK version is bumped
+export const npClient = new NutriPatrol(customFetch, { 
+    baseUrl: import.meta.env.VITE_API_URL || "https://nutripatrol.openfoodfacts.org" 
+});
+
+// For convenience, also expose the integrated client
+export const sdk = offClient;

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -3,6 +3,8 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import CheckIcon from '@mui/icons-material/Check';
 import LoopIcon from '@mui/icons-material/Loop';
 import { useState } from 'react';
+// @ts-ignore
+import { offClient } from '../api';
 import axios from 'axios';
 
 interface DeleteButtonProps {
@@ -27,6 +29,9 @@ const DeleteButton = ({ barcode, imgids, handleImageDeleted }: DeleteButtonProps
             data.append('imgids', imgids)
             data.append('move_to_override', 'trash')
             try {
+                // TODO(sdk-bump): Switch to SDK's offClient.deleteProductImage() once SDK version is bumped
+                // await offClient.deleteProductImage(barcode, parseInt(imgids));
+
                 axios.post(
                     deleteUrl,
                     data,

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -10,6 +10,8 @@ import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
 import axios from 'axios';
 import { useState } from 'react';
+// @ts-ignore
+import { offClient } from '../api';
 import DeleteButton from './DeleteButton';
 
 const style = {
@@ -49,6 +51,9 @@ export default function ModalInfo({barcode}: ModalInfoProps) {
         return `${import.meta.env.VITE_PO_IMAGE_URL}/images/products/${part1}/${part2}/${part3}/${part4}/${imageId}.${def}.jpg`;
     }
     const handleTicketInfo = () => {
+        // TODO(sdk-bump): Switch to SDK's offClient.getProductV2() once SDK version is bumped
+        // const { data } = await offClient.getProductV2(barcode);
+
         axios.get(`${import.meta.env.VITE_PO_URL}/api/v2/product/${barcode}.json`).then((res) => {
             const usedData: any = {
                 name: res.data.product.product_name || null,

--- a/src/components/TicketsButtons.tsx
+++ b/src/components/TicketsButtons.tsx
@@ -1,6 +1,8 @@
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import { Link } from 'react-router-dom';
+// @ts-ignore
+import { npClient } from '../api';
 import axios from 'axios';
 import EditIcon from '@mui/icons-material/Edit';
 import NotInterestedIcon from '@mui/icons-material/NotInterested';
@@ -18,6 +20,10 @@ export default function BasicButtonGroup({id, barcode, setTickets, tickets}: Bas
     // Change status of ticket to archived
     function handleStatus(id: number, status: string) {
         try {
+            // TODO(sdk-bump): Switch to SDK's npClient.updateTicketStatus() once SDK version is bumped
+            // Replace 'as any' with imported TicketStatus type from the SDK
+            // await npClient.updateTicketStatus(id, status as any);
+
             axios.put(`${import.meta.env.VITE_API_URL}/tickets/${id}/status?status=${status}`)
             // remove ticket from tickets
             const updatedTickets = tickets.filter((ticket: any) => ticket.id !== id);

--- a/src/pages/FlagFormPage.tsx
+++ b/src/pages/FlagFormPage.tsx
@@ -10,6 +10,8 @@ import {
 } from '@mui/material';
 import axios from 'axios';
 import { useState, useContext, useEffect } from 'react';
+// @ts-ignore
+import { npClient, offClient } from '../api';
 import { useSearchParams } from 'react-router-dom';
 import { reasons, sources, flavors } from '../const/flagsConst';
 import LoginContext from '../contexts/login';
@@ -81,6 +83,10 @@ export default function FlagForm({ type_ }: FlagFormProps) {
         }
         if (type_ === 'image') {
             const url = buildUrl(formData.barcode, formData.image_id as string, '400');
+            
+            // TODO(sdk-bump): Switch to SDK's offClient.getProductV2() once SDK version is bumped
+            // const { data } = await offClient.getProductV2(formData.barcode);
+            
             axios.get(url).then(() => {
                 setImage(url);
             }
@@ -101,6 +107,10 @@ export default function FlagForm({ type_ }: FlagFormProps) {
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         try {
+            // TODO(sdk-bump): Switch to SDK's npClient.createFlag() once SDK version is bumped
+            // Replace 'as any' with imported FlagRequestBody type from the SDK
+            // await npClient.createFlag(formData as any);
+
             axios.post(`${import.meta.env.VITE_API_URL}/flags`, formData)
             .then(() => {
                 window.location.replace('/thanks');

--- a/src/pages/ImageModerationPage.tsx
+++ b/src/pages/ImageModerationPage.tsx
@@ -7,6 +7,8 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import { useEffect, useState } from 'react'
+// @ts-ignore
+import { npClient } from '../api'
 import axios from 'axios'
 import ImageTicket from '../components/ImageTicket';
 import Paginate from '../components/Paginate'
@@ -31,6 +33,11 @@ export default function ImageModerationPage() {
     const isMobile = useMediaQuery('(max-width:800px)')
 
     const fetchImageTickets = (url_: string) => {
+        // TODO(sdk-bump): Switch to SDK's npClient.getTickets() once SDK version is bumped
+        // Replace 'as any' with imported FlagReason type from the SDK
+        // const { data, error } = await npClient.getTickets({ type: "image", status: "open", page: currentPage, page_size: 10, reason: reason ? [reason as any] : undefined });
+        // const ticketsData = data?.tickets;
+
         axios.get(url_).then(async (res) => {         
             
             const ticketsData = res.data.tickets;
@@ -39,6 +46,11 @@ export default function ImageModerationPage() {
             setMaxPage(res.data.max_page)
 
             const ticketIds = ticketsData.map((ticket: any) => ticket.id);
+
+            // TODO(sdk-bump): Switch to SDK's npClient.getFlagsByTicketBatch() once SDK version is bumped
+            // const { data: flagsData } = await npClient.getFlagsByTicketBatch(ticketIds);
+            // const ticketIdToFlags = flagsData?.ticket_id_to_flags;
+
             const flagsResponse = await axios.post(`${import.meta.env.VITE_API_URL}/flags/batch`, {
                 ticket_ids: ticketIds
             });

--- a/src/pages/ModerationPage.tsx
+++ b/src/pages/ModerationPage.tsx
@@ -6,6 +6,8 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import { useEffect, useState } from 'react'
+// @ts-ignore
+import { npClient } from '../api'
 import axios from 'axios'
 import Ticket from '../components/Ticket'
 import Paginate from '../components/Paginate'
@@ -38,12 +40,21 @@ export default function ImageModerationPage() {
         const url = `${import.meta.env.VITE_API_URL}/tickets?type_=product&status=open&page=${currentPage}&page_size=8`
         const fetchTickets = async () => {
             try {
+                // TODO(sdk-bump): Switch to SDK's npClient.getTickets() once SDK version is bumped
+                // const { data, error } = await npClient.getTickets({ type: "product", status: "open", page: currentPage, page_size: 8 });
+                // const ticketsData = data?.tickets;
+
                 const response = await axios.get(url);
                 const ticketsData = response.data.tickets;
                 setTickets(ticketsData);
                 setMaxPage(response.data.max_page);
 
                 const ticketIds = ticketsData.map((ticket: any) => ticket.id);
+                
+                // TODO(sdk-bump): Switch to SDK's npClient.getFlagsByTicketBatch() once SDK version is bumped
+                // const { data: flagsData } = await npClient.getFlagsByTicketBatch(ticketIds);
+                // const ticketIdToFlags = flagsData?.ticket_id_to_flags;
+
                 const flagsResponse = await axios.post(`${import.meta.env.VITE_API_URL}/flags/batch`, {
                     ticket_ids: ticketIds
                 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,6 +707,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@openfoodfacts/openfoodfacts-nodejs@2.0.0-alpha.29":
+  version "2.0.0-alpha.29"
+  resolved "https://registry.yarnpkg.com/@openfoodfacts/openfoodfacts-nodejs/-/openfoodfacts-nodejs-2.0.0-alpha.29.tgz#bda7ae1b07b7bb6ba57c280892853ff1450f1d97"
+  integrity sha512-063EZyqR7rc51X7LusdbkEIc0CK4KLE0uMKi5Ee7K72H9nAFlo3OGByreAK/7eryzCNVuAHSy2uLjNjhmbyJ4w==
+  dependencies:
+    openapi-fetch "^0.15.0"
+
 "@popperjs/core@^2.11.8":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -1824,6 +1831,18 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
+openapi-fetch@^0.15.0:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/openapi-fetch/-/openapi-fetch-0.15.2.tgz#f3d0ede1ef8e1bf883af3e020a9eda20ee9bd999"
+  integrity sha512-rdYTzUmSsJevmNqg7fwUVGuKc2Gfb9h6ph74EVPkPfIGJaZTfqdIbJahtbJ3qg1LKinln30hqZniLnKpH0RJBg==
+  dependencies:
+    openapi-typescript-helpers "^0.0.15"
+
+openapi-typescript-helpers@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz#96ffa762a5e01ef66a661b163d5f1109ed1967ed"
+  integrity sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==
 
 optionator@^0.9.3:
   version "0.9.3"


### PR DESCRIPTION
### What
It sets up the groundwork for migrating the Nutri-Patrol frontend from raw `axios` calls to the official `@openfoodfacts/openfoodfacts-nodejs` SDK. It introduces the SDK infrastructure while maintaining the existing API layer to ensure zero downtime during the transition phase.

-  Added `@openfoodfacts/openfoodfacts-nodejs` v2.0.0-alpha.29.
- Created `src/api.ts` to manage the initialization of `OpenFoodFacts` and `NutriPatrol` clients with shared configuration (User-Agent, Auth state).
-  Added `// TODO(sdk-bump)` comments next to all existing axios calls, pre-writing the equivalent SDK logics

### Future Work 
Once the SDK PR(https://github.com/openfoodfacts/openfoodfacts-js/pull/819) is merged and a newer version of SDK is published :
1. Update `package.json` to the newer SDK version.
2. In `src/api.ts`, remove the manual `NutriPatrol` instantiation and use `offClient.nutriPatrol` directly.
3. Uncomment the SDK calls and remove the `axios` implementation.
4. Delete temporary `@ts-ignore` markers used during this hybrid phase.

### Part of 
- https://github.com/openfoodfacts/nutripatrol/issues/26
